### PR TITLE
Increase retries

### DIFF
--- a/platform/src/config/services/replay-parse-service.json
+++ b/platform/src/config/services/replay-parse-service.json
@@ -13,7 +13,7 @@
     "secure": true
   },
   "ballchasing": {
-    "maxRetries": 4,
+    "maxRetries": 7,
     "backoffFactor": 4
   },
   "tempDir": "/tmp",


### PR DESCRIPTION
Increase retries (while following the exponential backoff policy) to ameliorate support load during times of increasing ballchasing load/queue size.